### PR TITLE
Application.quitting instead of MonoBehaviour.OnApplicationQuit

### DIFF
--- a/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/MainThreadDispatcher.cs
+++ b/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/MainThreadDispatcher.cs
@@ -497,7 +497,9 @@ namespace UniRx
                 updateMicroCoroutine = new MicroCoroutine(ex => unhandledExceptionCallback(ex));
                 fixedUpdateMicroCoroutine = new MicroCoroutine(ex => unhandledExceptionCallback(ex));
                 endOfFrameMicroCoroutine = new MicroCoroutine(ex => unhandledExceptionCallback(ex));
-
+                
+                Application.quitting += OnApplicationQuitting;
+    
                 StartCoroutine(RunUpdateMicroCoroutine());
                 StartCoroutine(RunFixedUpdateMicroCoroutine());
                 StartCoroutine(RunEndOfFrameMicroCoroutine());
@@ -590,7 +592,7 @@ namespace UniRx
             {
                 instance = GameObject.FindObjectOfType<MainThreadDispatcher>();
                 initialized = instance != null;
-
+                Application.quitting -= OnApplicationQuitting;
                 /*
                 // Although `this` still refers to a gameObject, it won't be found.
                 var foundDispatcher = GameObject.FindObjectOfType<MainThreadDispatcher>();
@@ -669,7 +671,7 @@ namespace UniRx
 
         Subject<Unit> onApplicationQuit;
 
-        void OnApplicationQuit()
+        void OnApplicationQuitting()
         {
             isQuitting = true;
             if (onApplicationQuit != null) onApplicationQuit.OnNext(Unit.Default);


### PR DESCRIPTION
`MonoBehaviour.OnApplicationQuit` is called before `Application.wantsToQuit` fires
which leads to undesired behavior. `Application.wantsToQuit` can be used to interrupt
a quit process, so you can show the user a window ("do you really want to quit?").
If you cancel the quit, but `MonoBehaviour.OnApplicationQuit` executes anyways, stuff breaks. 
I am aware this changes current behavior and is dealing with inconsistencies in the Unity API